### PR TITLE
Potential fix for duplicate items

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -159,7 +159,7 @@ namespace AssetPacksManager
 
                         var cidFilename = EnvPath.kUserDataPath + "\\" + relativePath + "\\" + fileName + ".Prefab.cid";
                         using StreamReader sr = new StreamReader(cidFilename);
-                        var guid = new Guid(sr.ReadToEnd());
+                        var guid = sr.ReadToEnd();
                         sr.Close();
                         AssetDatabase.user.AddAsset<PrefabAsset>(path, guid);
                         Log("Prefab added to database successfully");


### PR DESCRIPTION
It looks like if a new GUID is assigned from the CID, it tries to read it and as a result, recreates it with a flipping algorithm. Removing the new GUID seems to keep the GUID from the CID and loads only one copy of the asset.